### PR TITLE
Update the translation for "Cancel" in Ukrainian

### DIFF
--- a/quasar/lang/uk.js
+++ b/quasar/lang/uk.js
@@ -8,7 +8,7 @@ export default {
   label: {
     clear: 'Очистити',
     ok: 'OK',
-    cancel: 'Відміна',
+    cancel: 'Скасувати',
     close: 'Закрити',
     set: 'Встановити',
     select: 'Обрати',


### PR DESCRIPTION
I am a native Ukrainian speaker. I suggest the word which sounds more authentic to the Ukrainian language, replacing the late artificial borrowing from Russian.
